### PR TITLE
Vcpkg integration

### DIFF
--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -44,7 +44,7 @@ jobs:
 
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [ lin-build ]
+    needs: [ lin-build, win-build ]
     env:
       CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
     runs-on: ubuntu-latest

--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -26,7 +26,7 @@ jobs:
   win-build:
     runs-on: windows-latest
     env:
-      LIBCLANG_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm
+      LIBCLANG_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin
     steps:
     - uses: actions/checkout@v2
     - name: Install stable

--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -26,7 +26,7 @@ jobs:
   win-build:
     runs-on: windows-latest
     env:
-      LIBCLANG_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Tools\Llvm
+      LIBCLANG_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm
     steps:
     - uses: actions/checkout@v2
     - name: Install stable

--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -25,9 +25,11 @@ jobs:
 
   win-build:
     runs-on: windows-latest
-    env:
-      LIBCLANG_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin
     steps:
+    - name: Set up Visual Studio shell
+      uses: egor-tensin/vs-shell@v2-
+    - name: Set up LIBCLANG_PATH
+      run:  echo "LIBCLANG_PATH=$env:VCINSTALLDIR\Tools\Llvm\x64\bin" >> $env:GITHUB_ENV
     - uses: actions/checkout@v2
     - name: Install stable
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -23,25 +23,24 @@ jobs:
     - name: Run tests
       run: cargo test --lib --verbose
 
-# win build disabled for now
-#  win-build:
-#    runs-on: windows-latest
-#    env:
-#      VCPKG_DEFAULT_TRIPLET: x64-windows
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Install assimp
-#      run: pwsh -command ".\$GITHUB_WORKSPACE\install_assimp.ps1"
-#    - name: Install stable
-#      uses: actions-rs/toolchain@v1
-#      with:
-#        profile: minimal
-#        toolchain: stable
-#        override: true
-#    - name: Build
-#      run: cargo build --verbose
-#    - name: Run tests
-#      run: cargo test --lib --verbose
+  win-build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: install cargo-vcpkg
+      run: cargo install cargo-vcpkg
+    - name: vcpkg build
+      run: cargo vcpkg build
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --lib --verbose
 
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -25,6 +25,8 @@ jobs:
 
   win-build:
     runs-on: windows-latest
+    env:
+      LIBCLANG_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Tools\Llvm
     steps:
     - uses: actions/checkout@v2
     - name: Install stable

--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Set up Visual Studio shell
-      uses: egor-tensin/vs-shell@v2-
+      uses: egor-tensin/vs-shell@v2
     - name: Set up LIBCLANG_PATH
       run:  echo "LIBCLANG_PATH=$env:VCINSTALLDIR\Tools\Llvm\x64\bin" >> $env:GITHUB_ENV
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "russimp-sys"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Jhonny Knaak de Vargas"]
 edition = "2018"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 
 [build-dependencies]
 bindgen = "0.57.0"
+vcpkg = "0.2"
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,11 @@ path = "src/lib.rs"
 
 [build-dependencies]
 bindgen = "0.57.0"
+
+[package.metadata.vcpkg]
+git = "https://github.com/microsoft/vcpkg"
+rev = "9ab3baf"
+
+[package.metadata.vcpkg.target]
+x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md", install = ["assimp"] }
+x86-pc-windows-msvc = { triplet = "x86-windows-static-md", install = ["assimp"] }

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ There is a high chance that you are actually looking for russimp https://github.
 Pipeline is now building for windows as well, it is using vcpkg to get assimp.
 Please if youre a windows user, let me know if this is working on your side.
 
-
-
+This package uses [cargo-vcpkg](https://crates.io/crates/cargo-vcpkg) to manage system dependencies (particularly on 
+windows). Running ```cargo vcpkg build``` will build the necessary dependencies within the target directory. 
+Alternatively provide a VCPKG_ROOT environment variable pointed at the location of a shared vcpkg installation.

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,16 @@
 #![allow(unused_imports, dead_code, unused_variables)]
 
 use std::{env::var, path::PathBuf};
+use vcpkg::{find_package, Library};
 
 const BINDINGS_FILE: &str = "bindings.rs";
 const WRAPPER_FILE: &str = "wrapper.h";
 
 fn main() {
+    let (include, libdir, libname) = assimp_lib_data();
+
     bindgen::Builder::default()
+        .clang_arg(format!("-I{}", include))
         .header(WRAPPER_FILE)
         .whitelist_type("aiPostProcessSteps")
         .whitelist_type("aiPrimitiveType")
@@ -20,9 +24,37 @@ fn main() {
         .write_to_file(get_output_path(BINDINGS_FILE))
         .unwrap();
 
-    println!("cargo:rustc-link-search={}", "/usr/local/lib");
-    println!("cargo:include={}", "/usr/local/include");
-    println!("cargo:rustc-flags=-l assimp");
+    println!("cargo:rustc-link-search={}", libdir);
+    println!("cargo:include={}", include);
+    println!("cargo:rustc-link-lib={}", libname);
+}
+
+fn assimp_lib_data() -> (String, String, String) {
+    let lib = find_package("assimp").unwrap_or(Library {
+        include_paths: vec![PathBuf::from("/usr/local/include")],
+        link_paths: vec![PathBuf::from("/usr/local/lib")],
+        found_names: vec!["assimp".to_owned()],
+
+        ports: vec![],
+        cargo_metadata: vec![],
+        dll_paths: vec![],
+        found_dlls: vec![],
+
+        is_static: false,
+        found_libs: vec![],
+        vcpkg_triplet: "".to_string(),
+    });
+
+    (
+        lib.include_paths[0].to_str().unwrap().to_owned(),
+        lib.link_paths[0].to_str().unwrap().to_owned(),
+        lib.found_names
+            .iter()
+            .filter(|n| n.starts_with("assimp"))
+            .nth(0)
+            .unwrap()
+            .to_owned(),
+    )
 }
 
 fn get_output_path<'a>(content: &str) -> String {

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ fn main() {
         .whitelist_function("aiImportFileFromMemory")
         .whitelist_function("aiReleaseImport")
         .whitelist_function("aiGetErrorString")
+        .generate_comments(false)
         .generate()
         .unwrap()
         .write_to_file(get_output_path(BINDINGS_FILE))


### PR DESCRIPTION
An attempt to fix #14.

The solution here is using cargo-vcpkg to manage vcpkg. When you```cargo vcpkg build``` it will walk the dependency tree for vcpkg dependencies and then build anything it finds. This will place the vcpkg directory inside the target directory (I haven't tested but assume it would play nice with cargo workspaces as well). 

To resolve the correct libdir and libname, i've reworked the build script to use the rust vcpkg build dependency to probe for assimp build information. The good thing about this is that the same code will work regardless of whether the developer is using per-project dependencies with cargo vcpkg or has a central vcpkg install (via a provided VCPKG_ROOT). In theory if it can't find vcpkg or it can't find assimp inside vcpkg it will default to the values originally provided so i believe this should maintain the same build behaviour for people not using vcpkg (in theory someone could use vcpkg on linux or mac and this should work just as well for them... obviously haven't tested this).

I also switched the cargo instruction from specifying rustc flags to the builtin "rustc-link-lib". Wasn't critical but it seemed like a good idea at the time... i can obviously roll that back if there was an explicit reason to specify flags instead. 

Something else worth noting... vcpkg by default will output cargo directives and i haven't squelched that behaviour so if the vcpkg probe finds assimp it will output rustc-link-lib twice for the assimp library. This doesn't seem to cause a problem so I left it in place.
