### PR TITLE
Fix build on macOS with assimp installed with brew

### DIFF
--- a/.github/workflows/russimp-sys.yml
+++ b/.github/workflows/russimp-sys.yml
@@ -46,9 +46,26 @@ jobs:
     - name: Run tests
       run: cargo test --lib --verbose
 
+  macos-build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install assimp
+      run: brew install assimp
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --lib --verbose
+
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [ lin-build, win-build ]
+    needs: [ lin-build, win-build, macos-build ]
     env:
       CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "russimp-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jhonny Knaak de Vargas"]
 edition = "2018"
 license-file = "LICENSE"

--- a/build.rs
+++ b/build.rs
@@ -38,8 +38,12 @@ fn main() {
 }
 
 fn assimp_lib_data() -> (String, String, String) {
+    let target = std::env::var("TARGET").unwrap();
+
+    let include_path = if target.contains("apple") { "/opt/homebrew/opt/assimp/include" } else { "/usr/local/include"};
+
     let lib = find_package("assimp").unwrap_or(Library {
-        include_paths: vec![PathBuf::from("/usr/local/include")],
+        include_paths: vec![PathBuf::from(include_path)],
         link_paths: vec![PathBuf::from("/usr/local/lib")],
         found_names: vec!["assimp".to_owned()],
 


### PR DESCRIPTION
If user installed assimp with "brew install assimp", the headers are in
"/opt/brew/opt/assimp/include".