### PR TITLE
Add windows system library dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "russimp-sys"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Jhonny Knaak de Vargas"]
 edition = "2018"
 license-file = "LICENSE"

--- a/build.rs
+++ b/build.rs
@@ -57,6 +57,13 @@ fn assimp_lib_data() -> (String, String, String) {
         vcpkg_triplet: "".to_string(),
     });
 
+    if cfg!(target_os = "windows") {
+        // Following dependencies are pulled in via Irrlicht.
+        // vcpkg doesn't know how to find these system dependencies, so we list them here.
+        println!("cargo:rustc-link-lib=user32");
+        println!("cargo:rustc-link-lib=gdi32");
+    }
+
     (
         lib.include_paths[0].to_str().unwrap().to_owned(),
         lib.link_paths[0].to_str().unwrap().to_owned(),


### PR DESCRIPTION
When linking on Windows, vcpkg doesn't have a good way of expressing
which system libraries are also required for the link.

It looks like upstream vcpkg changed assimp's dependnecy on irrXML to
depend on irrlicht, which in turn pulls in the need to depend on these
core libraries.