### PR TITLE
Improve build on clean environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,27 @@ edition = "2021"
 license-file = "LICENSE"
 readme = "README.md"
 homepage = "https://github.com/jkvargas/russimp-sys"
-categories = ["rendering", "external-ffi-bindings", "game-engines", "multimedia"]
+categories = [
+    "rendering",
+    "external-ffi-bindings",
+    "game-engines",
+    "multimedia",
+]
 keywords = ["assimp", "3d", "blend", "3ds", "glTF"]
 repository = "https://github.com/jkvargas/russimp-sys"
 description = "Raw Assimp bindings for Rust"
-exclude = ["/assimp", "*.bash", "*.ps1"]
+include = [
+    "/assimp/include/assimp/**/*.{h,inl}",
+    "/src/",
+    "/bin/",
+    "/build.rs",
+    "/wrapper.h",
+    "/Cargo.toml",
+    "/LICENSE",
+    "/README.md",
+    "!*.bash",
+    "!*.ps1",
+]
 
 [lib]
 name = "russimp_sys"
@@ -37,6 +53,6 @@ bindgen = "0.63.0"
 built = "0.5.2"
 cmake = "0.1.49"
 flate2 = "1.0.25"
-reqwest =  { version = "0.11.13", features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11.13", features = ["blocking", "rustls-tls"] }
 tar = "0.4.38"
 which = "4.3.0"

--- a/build.rs
+++ b/build.rs
@@ -158,6 +158,14 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
+    // Look for assimp lib in Brew install paths on MacOS.
+    // See https://stackoverflow.com/questions/70497361/homebrew-mac-m1-cant-find-installs
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    println!("cargo:rustc-link-search=native=/opt/homebrew/lib/");
+
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    println!("cargo:rustc-link-search=native=/opt/brew/lib/");
+
     if cfg!(feature = "build-assimp") {
         build_from_source();
     } else if cfg!(feature = "prebuilt") {

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,10 @@ const fn build_zlib() -> bool {
     cfg!(not(feature = "nozlib"))
 }
 
+const fn build_assimp() -> bool {
+    cfg!(feature = "build-assimp")
+}
+
 // Compiler specific compiler flags for CMake
 fn compiler_flags() -> Vec<&'static str> {
     let mut flags = Vec::new();
@@ -40,7 +44,7 @@ fn lib_names() -> Vec<Library> {
         names.push(Library("assimp", static_lib()));
     }
 
-    if build_zlib() {
+    if build_assimp() && build_zlib() {
         names.push(Library("zlibstatic", "static"));
     } else {
         names.push(Library("z", "dylib"));
@@ -166,7 +170,7 @@ fn main() {
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     println!("cargo:rustc-link-search=native=/opt/brew/lib/");
 
-    if cfg!(feature = "build-assimp") {
+    if build_assimp() {
         build_from_source();
     } else if cfg!(feature = "prebuilt") {
         link_from_package();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,14 @@ impl From<&aiString> for String {
         .into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A simple test to make sure assimp library linked properly.
+    #[test]
+    fn test_version() {
+        let _ = unsafe { aiGetVersionMajor() };
+    }
+}


### PR DESCRIPTION
I decided to give `russimp-sys` a try on clean Mac environment and encountered lots of small build issues. Solving ones could potentially make life a bit easier.

So I’ve include the sys crate in my project and got this error

```
  --- stderr
  wrapper.h:1:10: fatal error: 'assimp/aabb.h' file not found
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ClangDiagnostic("wrapper.h:1:10: fatal error: 'assimp/aabb.h' file not found\n")', /Users/mxpv/.cargo/registry/src/index.crates.io-6f17d22bba15001f/russimp-sys-2.0.0/build.rs:181:10
```

Apparently assimp headers must be included even when not building from source.
[536fa43](https://github.com/jkvargas/russimp-sys/pull/34/commits/536fa43c40deca373b680cd281fdef4c3421cb69) Includes headers in the crate package, so it no longer fails.

<details>

```bash
❯ cargo publish --dry-run --allow-dirty -v
    Updating crates.io index
   Packaging russimp-sys v2.0.0 (/Users/mxpv/Github/russimp-sys)
   Archiving Cargo.lock
   Archiving Cargo.toml
   Archiving Cargo.toml.orig
   Archiving LICENSE
   Archiving README.md
   Archiving assimp/include/assimp/AssertHandler.h
   Archiving assimp/include/assimp/BaseImporter.h
   Archiving assimp/include/assimp/Bitmap.h
   Archiving assimp/include/assimp/BlobIOSystem.h
   Archiving assimp/include/assimp/ByteSwapper.h
   Archiving assimp/include/assimp/ColladaMetaData.h
   Archiving assimp/include/assimp/Compiler/poppack1.h
   Archiving assimp/include/assimp/Compiler/pstdint.h
   Archiving assimp/include/assimp/Compiler/pushpack1.h
   Archiving assimp/include/assimp/CreateAnimMesh.h
   Archiving assimp/include/assimp/DefaultIOStream.h
   Archiving assimp/include/assimp/DefaultIOSystem.h
   Archiving assimp/include/assimp/Exceptional.h
   Archiving assimp/include/assimp/GenericProperty.h
   Archiving assimp/include/assimp/GltfMaterial.h
   Archiving assimp/include/assimp/Hash.h
   Archiving assimp/include/assimp/IOStreamBuffer.h
   Archiving assimp/include/assimp/LineSplitter.h
   Archiving assimp/include/assimp/LogAux.h
   Archiving assimp/include/assimp/MathFunctions.h
   Archiving assimp/include/assimp/MemoryIOWrapper.h
   Archiving assimp/include/assimp/ObjMaterial.h
   Archiving assimp/include/assimp/ParsingUtils.h
   Archiving assimp/include/assimp/Profiler.h
   Archiving assimp/include/assimp/RemoveComments.h
   Archiving assimp/include/assimp/SGSpatialSort.h
   Archiving assimp/include/assimp/SceneCombiner.h
   Archiving assimp/include/assimp/SkeletonMeshBuilder.h
   Archiving assimp/include/assimp/SmallVector.h
   Archiving assimp/include/assimp/SmoothingGroups.h
   Archiving assimp/include/assimp/SmoothingGroups.inl
   Archiving assimp/include/assimp/SpatialSort.h
   Archiving assimp/include/assimp/StandardShapes.h
   Archiving assimp/include/assimp/StreamReader.h
   Archiving assimp/include/assimp/StreamWriter.h
   Archiving assimp/include/assimp/StringComparison.h
   Archiving assimp/include/assimp/StringUtils.h
   Archiving assimp/include/assimp/Subdivision.h
   Archiving assimp/include/assimp/TinyFormatter.h
   Archiving assimp/include/assimp/Vertex.h
   Archiving assimp/include/assimp/XMLTools.h
   Archiving assimp/include/assimp/XmlParser.h
   Archiving assimp/include/assimp/ZipArchiveIOSystem.h
   Archiving assimp/include/assimp/aabb.h
   Archiving assimp/include/assimp/ai_assert.h
   Archiving assimp/include/assimp/anim.h
   Archiving assimp/include/assimp/camera.h
   Archiving assimp/include/assimp/cexport.h
   Archiving assimp/include/assimp/cfileio.h
   Archiving assimp/include/assimp/cimport.h
   Archiving assimp/include/assimp/color4.h
   Archiving assimp/include/assimp/color4.inl
   Archiving assimp/include/assimp/commonMetaData.h
   Archiving assimp/include/assimp/defs.h
   Archiving assimp/include/assimp/fast_atof.h
   Archiving assimp/include/assimp/importerdesc.h
   Archiving assimp/include/assimp/light.h
   Archiving assimp/include/assimp/material.h
   Archiving assimp/include/assimp/material.inl
   Archiving assimp/include/assimp/matrix3x3.h
   Archiving assimp/include/assimp/matrix3x3.inl
   Archiving assimp/include/assimp/matrix4x4.h
   Archiving assimp/include/assimp/matrix4x4.inl
   Archiving assimp/include/assimp/mesh.h
   Archiving assimp/include/assimp/metadata.h
   Archiving assimp/include/assimp/pbrmaterial.h
   Archiving assimp/include/assimp/port/AndroidJNI/AndroidJNIIOSystem.h
   Archiving assimp/include/assimp/port/AndroidJNI/BundledAssetIOSystem.h
   Archiving assimp/include/assimp/postprocess.h
   Archiving assimp/include/assimp/qnan.h
   Archiving assimp/include/assimp/quaternion.h
   Archiving assimp/include/assimp/quaternion.inl
   Archiving assimp/include/assimp/scene.h
   Archiving assimp/include/assimp/texture.h
   Archiving assimp/include/assimp/types.h
   Archiving assimp/include/assimp/vector2.h
   Archiving assimp/include/assimp/vector2.inl
   Archiving assimp/include/assimp/vector3.h
   Archiving assimp/include/assimp/vector3.inl
   Archiving assimp/include/assimp/version.h
   Archiving bin/package/main.rs
   Archiving build.rs
   Archiving src/lib.rs
   Archiving wrapper.h
   Verifying russimp-sys v2.0.0 (/Users/mxpv/Github/russimp-sys)
   Compiling libc v0.2.148
```

</details>

After the fix above, I started seeing linker problems (on MacOS)

```
  = note: ld: library 'assimp' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

So I ran `brew install assimp`, but that did not help.
Looks like the build script doesn’t take into account `brew` directories,
[4537f5d](https://github.com/jkvargas/russimp-sys/pull/34/commits/4537f5dff5313067e51d470cc01a1e43ed986b41) adds brew to search paths.

and lastly ZLib.

zlib feature is enabled by default, but it makes sense only when building from source code, which is disabled by default. If we’re not building from source, we should expect zlib to exist (same as assimp).

I confirmed this to work on both Intel and M1 macs (with just `brew install assimp` as prerequisite).

<details>

```bash
❯ cargo test
   Compiling russimp-sys v2.0.0 (/Users/mxpv/Github/russimp-sys)
    Finished test [unoptimized + debuginfo] target(s) in 3.54s
     Running unittests src/lib.rs (target/debug/deps/russimp_sys-37468f7323fd3374)

running 46 tests
test bindgen_test_layout_aiAABB ... ok
test bindgen_test_layout_aiBone ... ok
test bindgen_test_layout_aiAnimMesh ... ok
test bindgen_test_layout_aiColor3D ... ok
test bindgen_test_layout_aiAnimation ... ok
test bindgen_test_layout_aiCamera ... ok
test bindgen_test_layout_aiColor4D ... ok
test bindgen_test_layout_aiExportDataBlob ... ok
test bindgen_test_layout_aiExportFormatDesc ... ok
test bindgen_test_layout_aiFace ... ok
test bindgen_test_layout_aiFileIO ... ok
test bindgen_test_layout_aiFile ... ok
test bindgen_test_layout_aiImporterDesc ... ok
test bindgen_test_layout_aiLogStream ... ok
test bindgen_test_layout_aiLight ... ok
test bindgen_test_layout_aiMaterial ... ok
test bindgen_test_layout_aiMaterialProperty ... ok
test bindgen_test_layout_aiMatrix3x3 ... ok
test bindgen_test_layout_aiMatrix4x4 ... ok
test bindgen_test_layout_aiMemoryInfo ... ok
test bindgen_test_layout_aiMesh ... ok
test bindgen_test_layout_aiMeshAnim ... ok
test bindgen_test_layout_aiMeshKey ... ok
test bindgen_test_layout_aiMeshMorphAnim ... ok
test bindgen_test_layout_aiMeshMorphKey ... ok
test bindgen_test_layout_aiMetadata ... ok
test bindgen_test_layout_aiMetadataEntry ... ok
test bindgen_test_layout_aiNode ... ok
test bindgen_test_layout_aiNodeAnim ... ok
test bindgen_test_layout_aiPlane ... ok
test bindgen_test_layout_aiPropertyStore ... ok
test bindgen_test_layout_aiQuatKey ... ok
test bindgen_test_layout_aiQuaternion ... ok
test bindgen_test_layout_aiRay ... ok
test bindgen_test_layout_aiScene ... ok
test bindgen_test_layout_aiSkeleton ... ok
test bindgen_test_layout_aiSkeletonBone ... ok
test bindgen_test_layout_aiString ... ok
test bindgen_test_layout_aiTexel ... ok
test bindgen_test_layout_aiTexture ... ok
test bindgen_test_layout_aiUVTransform ... ok
test bindgen_test_layout_aiVector2D ... ok
test bindgen_test_layout_aiVector3D ... ok
test bindgen_test_layout_aiVectorKey ... ok
test bindgen_test_layout_aiVertexWeight ... ok
test tests::test_version ... ok

test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests bin/package/main.rs (target/debug/deps/package-8557b93c4a9b2be6)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

</details>