### PR TITLE
Build and test bindings against preinstalled assimp on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,12 @@ jobs:
             triple: x86_64-apple-darwin
           - os: windows-latest
             triple: x86_64-pc-windows-msvc
-        features: [ 'build-assimp', 'static-link' ]
+        features: [ 'build-assimp', 'static-link', '' ]
+        exclude:
+          # TODO: Fix static linking on Windows
+          - target:
+              os: windows-latest
+            features: ''
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,8 +56,28 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
 
+      # No build features enabled, make sure it works with assimp
+      # installed on the system via package manager.
+      - name: Install dependencies
+        if: matrix.features == ''
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == 'Linux' ]; then
+            # Install on Ubuntu
+            # https://github.com/assimp/assimp/blob/master/Build.md#install-on-ubuntu
+            sudo apt-get update
+            sudo apt-get install libassimp-dev
+          elif [ "$RUNNER_OS" == 'macOS' ]; then
+              brew install assimp
+          elif [ "$RUNNER_OS" == 'Windows' ]; then
+              vcpkg install assimp
+          else
+              echo "Unsupported OS: $RUNNER_OS"
+              exit 1
+          fi
+
       - name: Build
-        run: cargo build --target ${{ matrix.target.triple }} --features ${{ matrix.features }}
+        run: cargo build --target ${{ matrix.target.triple }} --features '${{ matrix.features }}'
 
       - name: Test
-        run: cargo test --target ${{ matrix.target.triple }} --features ${{ matrix.features }}
+        run: cargo test --target ${{ matrix.target.triple }} --features '${{ matrix.features }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - '!v*' # Exclude tags starting with 'v'
     pull_request:
+  schedule:
+    - cron: '0 0 * * 0'  # Run weekly (every Sunday night at midnight UTC)
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Follow up to https://github.com/jkvargas/russimp-sys/pull/34

This is to make sure that the bindings work against `assimp` preinstalled on the system. 

Note: this only enables Linux and MacOS, Windows [needs more work](https://github.com/mxpv/russimp-sys/actions/runs/6513876804/job/17694246863?pr=1), but I don't have proper environment.

Also, because we install assimp from package manager and versions can change, the CI job will be running every week to help catch potential problems with new releases.
