### PR TITLE
Fix zlib library name

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -47,7 +47,7 @@ fn lib_names() -> Vec<Library> {
     if build_assimp() && build_zlib() {
         names.push(Library("zlibstatic", "static"));
     } else {
-        names.push(Library("z", "dylib"));
+        names.push(Library("zlibstatic", "dylib"));
     }
 
     if cfg!(target_os = "linux") {


### PR DESCRIPTION
The name of the zlib library in the zip files you are hosting (when using feature `prebuilt`) is "zlibstatic", not just "z". Without this fix, the following causes linker errors:
- Clone repo
- `cargo build -F prebuilt`