### PR TITLE
Fix building from source by including source in published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["assimp", "3d", "blend", "3ds", "glTF"]
 repository = "https://github.com/jkvargas/russimp-sys"
 description = "Raw Assimp bindings for Rust"
 include = [
-    "/assimp/include/assimp/**/*.{h,inl}",
+    "/assimp/",
     "/src/",
     "/bin/",
     "/build.rs",


### PR DESCRIPTION
Users of the published `russimp-sys` crate, which transitively includes `russimp`, can't really leverage the build from source feature because the published `russimp-sys` crate files don't include `assimp` sources, such as the CMake lists file, which are expected by the build script in this mode.

Ideally, [crate build scripts shouldn't download stuff from Internet](https://kornel.ski/rust-sys-crate), so let's just relax our file exclusion constraints. This will increase the published crate size, but render the build from source feature functional in the most error-proof way.