### PR TITLE
Reintroduce Windows GNU target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ We build, test, and provide prebuilt packages for the following targets:
 Additional targets that work when building from source:
 - aarch64-apple-darwin (M1 Macs, cross-compiled on x86_64.)
 - aarch64-unknown-linux-gnu (Raspberry Pi 4b, built on the machine itself.)
-
-Platforms that are not supported and won't build:
-- x86_64-pc-windows-gnu (See: [assimp/4686]([https://github.com/assimp/assimp/issues/4868))
+- x86_64-pc-windows-gnu
 
 ## Installation
 

--- a/build.rs
+++ b/build.rs
@@ -38,11 +38,7 @@ fn compiler_flags() -> Vec<&'static str> {
 fn lib_names() -> Vec<Library> {
     let mut names = Vec::new();
 
-    if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
-        panic!("Windows GNU is not supported, assimp fails to build for some reason.\nSee https://github.com/assimp/assimp/issues/4868");
-    } else {
-        names.push(Library("assimp", static_lib()));
-    }
+    names.push(Library("assimp", static_lib()));
 
     if build_assimp() && build_zlib() {
         names.push(Library("zlibstatic", "static"));


### PR DESCRIPTION
`assimp` historically had [problems building for the Windows platform with a GNU toolchain](https://github.com/assimp/assimp/issues/4868), but those problems have been fixed upstream some time ago. These bindings use the latest `assimp` release, so they contain those fixes already, and thus there is no point in artificially restricting support for a target that `assimp` can now deal with.

I've tested that indeed this target is supported by `assimp` by cross-compiling the Windows tools binary with the `mingw-w64` toolchain from a Linux host, and then running it under Wine with no problems.