### PR TITLE
Do not fail Assimp build from source if warnings are emitted

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,6 +88,9 @@ fn build_from_source() {
         .define("ASSIMP_BUILD_ASSIMP_TOOLS", "OFF")
         .define("ASSIMP_BUILD_TESTS", "OFF")
         .define("ASSIMP_BUILD_ZLIB", build_zlib)
+        // Disable being overly strict with warnings, which can cause build issues
+        // such as: https://github.com/assimp/assimp/issues/5315
+        .define("ASSIMP_WARNINGS_AS_ERRORS", "OFF")
         .define("LIBRARY_SUFFIX", "");
 
     // Add compiler flags


### PR DESCRIPTION
Different compilers may emit different warnings when building Assimp. While it's good for the upstream Assimp project to try to minimize warnings by failing a build on a compiler warning by default, for us it creates unnecessary failure modes that are very likely to be caught upstream anyway. For example, [GCC 13 as shipped on the latest Ubuntu release has an alleged compiler bug that triggers a warning](https://github.com/assimp/assimp/issues/5315), and thus fails the Assimp build, even though end-user functionality is not affected.

Let's define the CMake variable documented upstream to not treat warnings as errors, which should increase the resilience of our build from source process. Users interested in fixing the root cause of the warnings can still contribute to Assimp itself.