### PR TITLE
fix: static linking feature (and building from source)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "russimp-sys-fork"
+name = "russimp-sys"
 version = "2.0.3"
 authors = ["Jhonny Knaak de Vargas"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "russimp-sys"
+name = "russimp-sys-fork"
 version = "2.0.3"
 authors = ["Jhonny Knaak de Vargas"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,7 @@ flate2 = "1.0.25"
 reqwest = { version = "0.11.13", features = ["blocking", "rustls-tls"] }
 tar = "0.4.38"
 which = "4.3.0"
+zip = "0.6"
+# optional, but i prefer to use this
+# git2 = "0.20"
+# git2 = { version = "0.20", default-features = false, features = ["vendored-openssl"] }

--- a/build.rs
+++ b/build.rs
@@ -104,17 +104,17 @@ fn build_from_source() {
     let cmake_dir = cmake.build();
 
     let assimp_lib_path = cmake_dir.join("lib").join("assimp.lib");
-    if !assimp_lib_path.exists() {
-        panic!(
-"
-Error while compiling russimp-sys:
+//     if !assimp_lib_path.exists() {
+//         panic!(
+// "
+// Error while compiling russimp-sys:
 
-assimp.lib was not found (specifically at {}). The assimp build may have failed or made libraries in a different location. 
-Please check the CMake output and ensure all deps are installed. 
-",
-            assimp_lib_path.display()
-        );
-    }
+// assimp.lib was not found (specifically at {}). The assimp build may have failed or made libraries in a different location. 
+// Please check the CMake output and ensure all deps are installed. 
+// ",
+//             assimp_lib_path.display()
+//         );
+//     }
 
     println!(
         "cargo:rustc-link-search=native={}",

--- a/build.rs
+++ b/build.rs
@@ -182,7 +182,6 @@ fn ensure_submodules()
             }
         }
 
-        println!("cargo:warning=extracting zip file contents");
         let extracted_dir = out_dir.join("assimp-master");
         if extracted_dir.exists() {
             std::fs::rename(&extracted_dir, &assimp_dir)?;


### PR DESCRIPTION
there was an issue regarding static linking and building from source. i have fixed it by downloading a zip directly from the assimp repository. i originally thought of using the git2 library, however dealing with ssl issues wasn't within my scope, so i just used reqwest (its alr included). i have tested it out and it successfully works. 

hopefully i did good :)
-tk

note: issue related: https://github.com/jkvargas/russimp-sys/issues/49